### PR TITLE
Extend badge schema with auth protocol info

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,24 @@ Every badge specification is a JSON document with these top level keys:
   "requirements": { /* mandatory criteria */ },
   "optional_features": [ /* optional extras */ ],
   "verification": { /* how the badge is verified */ },
-  "status": "active",
+  "version": "1.0.0",
+  "auth_protocols": ["OIDC", "SAML", "LDAP"],
+  "docs_url": "https://example.com/docs/auth",
+  "status": "certified",
   "issued_since": "YYYY-MM-DD",
+  "expires_on": "YYYY-MM-DD", /* optional */
   "compatible_projects": [],
   "schema_version": "1.0"
 }
 ```
+
+Key fields explained:
+
+- `version` — semantic version of the badge entry. Certification applies only to this major version.
+- `auth_protocols` — one or more of `OIDC`, `SAML`, or `LDAP`.
+- `docs_url` — URI pointing to documentation of the implementation.
+- `status` — either `certified`, `revoked`, or `expired`.
+- `expires_on` — optional expiration date of the certification.
 
 ## ✅ Current Specification
 ### `Free SSO/IdP Support Badge v0.1`

--- a/examples/acme.json
+++ b/examples/acme.json
@@ -5,9 +5,10 @@
   "project": "https://github.com/example/open-idp-app",
   "project_name": "ACME OpenIDP App",
   "protocols": ["OIDC", "SAML", "LDAP"],
+  "auth_protocols": ["OIDC", "LDAP"],
   "self_hostable": true,
   "no_paywall": true,
-  "docs_url": "https://example.org/docs/sso",
+  "docs_url": "https://example.com/docs/auth",
   "verified_at": "2025-06-18",
   "verification_note": "Project offers built-in OIDC, SAML & LDAP support in free tier; verified via public documentation and test instance."
 }

--- a/examples/invalid.json
+++ b/examples/invalid.json
@@ -4,6 +4,7 @@
   "project": "https://github.com/hooli/social",
   "project_name": "Broken Entry",
   "protocols": "OIDC",
+  "auth_protocols": ["SSO"],
   "self_hostable": "yes",
   "no_paywall": true
 }

--- a/examples/sample-badge.json
+++ b/examples/sample-badge.json
@@ -5,9 +5,10 @@
   "project": "https://github.com/example/open-idp-app",
   "project_name": "OpenIDP App",
   "protocols": ["OIDC", "LDAP"],
+  "auth_protocols": ["OIDC", "LDAP"],
   "self_hostable": true,
   "no_paywall": true,
-  "docs_url": "https://example.org/docs/sso",
+  "docs_url": "https://example.com/docs/auth",
   "verified_at": "2025-06-18",
   "verification_note": "Project offers built-in OIDC & LDAP support in free tier; verified via public documentation and test instance."
 }

--- a/examples/valid.json
+++ b/examples/valid.json
@@ -5,9 +5,10 @@
   "project": "https://github.com/hooli/social",
   "project_name": "Hooli Social",
   "protocols": ["OIDC", "SAML"],
+  "auth_protocols": ["OIDC", "LDAP"],
   "self_hostable": true,
   "no_paywall": true,
-  "docs_url": "https://hooli.example.com/docs/sso",
+  "docs_url": "https://example.com/docs/auth",
   "verified_at": "2025-07-01",
   "verification_note": "Verified via open documentation and sample instance."
 }

--- a/specs/v1.0.0/badge-schema.json
+++ b/specs/v1.0.0/badge-schema.json
@@ -3,7 +3,17 @@
   "$id": "https://openauthcert.org/schema/badge-schema.json",
   "title": "OpenAuthCert Badge Specification Schema",
   "type": "object",
-  "required": ["badge", "requirements", "verification", "status", "issued_since", "schema_version"],
+  "required": [
+    "badge",
+    "requirements",
+    "verification",
+    "auth_protocols",
+    "docs_url",
+    "version",
+    "status",
+    "issued_since",
+    "schema_version"
+  ],
   "properties": {
     "badge": {
       "type": "object",
@@ -47,7 +57,24 @@
         "requires_narrative_explanation": { "type": "boolean" }
       }
     },
-    "status": { "type": "string" },
+    "auth_protocols": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["OIDC", "SAML", "LDAP"]
+      },
+      "minItems": 1
+    },
+    "docs_url": { "type": "string", "format": "uri" },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["certified", "revoked", "expired"]
+    },
+    "expires_on": { "type": "string", "format": "date" },
     "issued_since": { "type": "string", "format": "date" },
     "compatible_projects": {
       "type": "array",

--- a/specs/v1.0.0/free-sso-idp-v0.1.json
+++ b/specs/v1.0.0/free-sso-idp-v0.1.json
@@ -30,7 +30,10 @@
     "automatable": false,
     "requires_narrative_explanation": true
   },
-  "status": "active",
+  "auth_protocols": ["OIDC", "SAML", "LDAP"],
+  "docs_url": "https://example.com/docs/auth",
+  "version": "0.1.0",
+  "status": "certified",
   "issued_since": "2025-06-18",
   "compatible_projects": [],
   "schema_version": "1.0"

--- a/validation-guide.md
+++ b/validation-guide.md
@@ -40,3 +40,10 @@ print('Badge is valid!')
 
 Any validation errors will raise an exception detailing the problem.
 
+## Schema Notes
+
+Required fields include `version`, `auth_protocols`, `docs_url`, and `status`.
+`auth_protocols` must list one or more of `OIDC`, `SAML`, or `LDAP`.
+`status` accepts `certified`, `revoked`, or `expired` and certification only applies to the stated major `version`.
+`expires_on` may optionally specify when a badge is no longer valid.
+


### PR DESCRIPTION
## Summary
- update badge schema to include auth protocols, docs url, version and status
- update Free SSO/IdP spec to satisfy new schema
- refresh example badge JSON files
- document new fields in README and validation guide

## Testing
- `python3 -m check_jsonschema specs/v1.0.0/free-sso-idp-v0.1.json --schemafile specs/v1.0.0/badge-schema.json`

------
https://chatgpt.com/codex/tasks/task_e_6856ea004c148323b96ec4d9d92ab728